### PR TITLE
Change returned queue items order

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "2.3.8"
+  s.version      = "2.3.9"
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "avo_2.3.8"}
+  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "avo_2.3.9"}
   s.platform     = :ios
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'

--- a/StreamingKit/StreamingKit/STKQueueMixer.m
+++ b/StreamingKit/StreamingKit/STKQueueMixer.m
@@ -434,16 +434,28 @@ static OSStatus OutputRenderCallback(void* inRefCon, AudioUnitRenderActionFlags*
 {
     NSMutableArray<STKMixableQueueEntry *> *queueArray = [[NSMutableArray alloc] init];
     
-    if (_mixBus0 != nil) {
-        [queueArray addObject:_mixBus0];
-    }
-    
-    if (_mixBus1 != nil) {
-        [queueArray addObject:_mixBus1];
-    }
-    
     if (_mixQueue != nil & [_mixQueue count] > 0) {
         [queueArray addObjectsFromArray:_mixQueue];
+    }
+    
+    if (_busState == BUS_0 || _busState == FADE_FROM_0) {
+        // Insert next track
+        if (_mixBus1 != nil) {
+            [queueArray addObject:_mixBus1];
+        }
+        // Insert current track
+        if (_mixBus0 != nil) {
+            [queueArray addObject:_mixBus0];
+        }
+    } else if (_busState == BUS_1 || _busState == FADE_FROM_1) {
+        // Insert next track
+        if (_mixBus0 != nil) {
+            [queueArray addObject:_mixBus0];
+        }
+        // Insert current track
+        if (_mixBus1 != nil) {
+            [queueArray addObject:_mixBus1];
+        }
     }
     
     return queueArray;


### PR DESCRIPTION
return Currently playing and Next items at the end of queue array (as it comes reversed). Based on what item is currently playing set their position in mixerQueue.

Order before:
[
  bus_0 (upnext / current)
  bus_1 (current / upnext)
  upnext-5
  upnext-4
  upnext-3
  upnext-2
  upnext-1
]

Now order should be:
[
  upnext-5
  upnext-4
  upnext-3
  upnext-2
  upnext-1
  upnext (bus_0 / bus_1)
  current (bus_1 / bus_0)
]