### PR TITLE
Respect redirect URLs

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "2.4.19"
+  s.version      = "2.4.20"
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.19"}
+  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.20"}
   s.platform     = :ios
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'

--- a/StreamingKit/StreamingKit/STKHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKHTTPDataSource.m
@@ -94,8 +94,6 @@
         audioFileTypeHint = [STKLocalFileDataSource audioFileTypeHintFromFileExtension:self->currentUrl.pathExtension];
     }
     
-    NSLog(@"STKHTTPDataSource init");
-    
     return self;
 }
 

--- a/StreamingKit/StreamingKit/STKHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKHTTPDataSource.m
@@ -48,7 +48,6 @@
     BOOL iceHeaderAvailable;
     BOOL httpHeaderNotAvailable;
 
-    NSURL* redirectUrl;
     NSURL* currentUrl;
     NSDictionary* httpHeaders;
     AudioFileTypeID audioFileTypeHint;
@@ -94,6 +93,8 @@
         
         audioFileTypeHint = [STKLocalFileDataSource audioFileTypeHintFromFileExtension:self->currentUrl.pathExtension];
     }
+    
+    NSLog(@"STKHTTPDataSource init");
     
     return self;
 }
@@ -206,15 +207,11 @@
 
 -(BOOL) parseHttpHeader
 {
+    NSURL *redirectUrl = nil;
     if (!httpHeaderNotAvailable)
     {
         CFTypeRef response = CFReadStreamCopyProperty(stream, kCFStreamPropertyHTTPResponseHeader);
-        NSURL *finalUrl = (__bridge_transfer NSURL*)CFReadStreamCopyProperty(stream, kCFStreamPropertyHTTPFinalURL);
-        
-        if (finalUrl)
-        {
-            self->redirectUrl = finalUrl;
-        }
+        redirectUrl = (__bridge_transfer NSURL*)CFReadStreamCopyProperty(stream, kCFStreamPropertyHTTPFinalURL);
         
         if (response)
         {


### PR DESCRIPTION
Updates the URL once it has been redirected in order to avoid further redirecting when seeking. It is important as some redirections attach sessionID to the new link and this change is not respected currently