### PR TITLE
fix: Calculate duration based on packet count

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "2.4.21"
+  s.version      = "2.4.22"
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.21"}
+  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.22"}
   s.platform     = :ios
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -869,6 +869,17 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
             
             break;
         }
+        case kAudioFileStreamProperty_AudioDataPacketCount:
+        {
+            UInt64 audioDataPacketCount;
+            UInt32 byteCountSize = sizeof(audioDataPacketCount);
+            
+            AudioFileStreamGetProperty(inAudioFileStream, kAudioFileStreamProperty_AudioDataPacketCount, &byteCountSize, &audioDataPacketCount);
+            
+            currentlyReadingEntry->audioPacketCount = audioDataPacketCount;
+            
+            break;
+        }
         case kAudioFileStreamProperty_AudioDataByteCount:
         {
             UInt64 audioDataByteCount;

--- a/StreamingKit/StreamingKit/STKQueueEntry.h
+++ b/StreamingKit/StreamingKit/STKQueueEntry.h
@@ -20,6 +20,7 @@
     double packetDuration;
     UInt64 audioDataOffset;
     UInt64 audioDataByteCount;
+    UInt64 audioPacketCount;
     UInt32 packetBufferSize;
     volatile Float64 seekTime;
     volatile SInt64 framesQueued;

--- a/StreamingKit/StreamingKit/STKQueueEntry.m
+++ b/StreamingKit/StreamingKit/STKQueueEntry.m
@@ -45,7 +45,7 @@
 	{
 		if (processedPacketsCount > STK_BIT_RATE_ESTIMATION_MIN_PACKETS_PREFERRED || (audioStreamBasicDescription.mBytesPerFrame == 0 && processedPacketsCount > STK_BIT_RATE_ESTIMATION_MIN_PACKETS_MIN))
 		{
-			double averagePacketByteSize = processedPacketsSizeTotal / processedPacketsCount;
+			double averagePacketByteSize = (processedPacketsSizeTotal * 1.0) / processedPacketsCount;
 			
 			retval = averagePacketByteSize / packetDuration * 8;
 			

--- a/StreamingKit/StreamingKit/STKQueueEntry.m
+++ b/StreamingKit/StreamingKit/STKQueueEntry.m
@@ -45,7 +45,7 @@
 	{
 		if (processedPacketsCount > STK_BIT_RATE_ESTIMATION_MIN_PACKETS_PREFERRED || (audioStreamBasicDescription.mBytesPerFrame == 0 && processedPacketsCount > STK_BIT_RATE_ESTIMATION_MIN_PACKETS_MIN))
 		{
-			double averagePacketByteSize = (processedPacketsSizeTotal * 1.0) / processedPacketsCount;
+			double averagePacketByteSize = (double)processedPacketsSizeTotal / (double)processedPacketsCount;
 			
 			retval = averagePacketByteSize / packetDuration * 8;
 			
@@ -67,7 +67,6 @@
     
     if (audioPacketCount > 0.0)
     {
-        
         return audioPacketCount * packetDuration;;
     }
     

--- a/StreamingKit/StreamingKit/STKQueueEntry.m
+++ b/StreamingKit/StreamingKit/STKQueueEntry.m
@@ -67,7 +67,7 @@
     
     if (audioPacketCount > 0.0)
     {
-        return audioPacketCount * packetDuration;;
+        return audioPacketCount * packetDuration;
     }
     
     UInt64 audioDataLengthInBytes = [self audioDataLengthInBytes];

--- a/StreamingKit/StreamingKit/STKQueueEntry.m
+++ b/StreamingKit/StreamingKit/STKQueueEntry.m
@@ -65,6 +65,12 @@
         return 0;
     }
     
+    if (audioPacketCount > 0.0)
+    {
+        
+        return audioPacketCount * packetDuration;;
+    }
+    
     UInt64 audioDataLengthInBytes = [self audioDataLengthInBytes];
     
     double calculatedBitRate = [self calculatedBitRate];


### PR DESCRIPTION
I've found that we can provide the exact duration if the total packets count is known. At some cases like m4a provides this information. In this case we can just calculate the duration based on `total packets * packet duration`.

The other change is something I found on the tumtumtum repo where they improve the duration calculation by the proper casting.