### PR TITLE
fix: Incorrect stop reason

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "2.4.22"
+  s.version      = "2.4.23"
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.22"}
+  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.23"}
   s.platform     = :ios
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -2815,6 +2815,8 @@ static OSStatus OutputRenderCallback(void* inRefCon, AudioUnitRenderActionFlags*
        
         if (lastFramePlayed && entry == currentlyPlayingEntry)
         {
+            [audioPlayer stopAudioUnitWithReason:STKAudioPlayerStopReasonEof];
+            
             [audioPlayer audioQueueFinishedPlaying:entry];
             
             while (extraFramesPlayedNotAssigned > 0)


### PR DESCRIPTION
At some cases an STKAudioPlayerStopReasonNone declared although the file reached the end. The issue can be reproduced from time to time when seeked to the end of the file. 

It happens as one thread declares that the file is ended on `OutputRenderCallback` and another thread declares the ending reason on the `processRunloop`. If the file ended thread happens first the stop reason won't be set. My fix makes sure when the lastFrame is played the end reason will be set as STKAudioPlayerStopReasonEof