### PR TITLE
Retry connection when no network

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "2.4.23"
+  s.version      = "2.4.24"
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.23"}
+  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.24"}
   s.platform     = :ios
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'

--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
-  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_2.4.24"}
+  s.source       = { :git => "https://github.com/GlobalRadio/StreamingKit.git", :tag => "guac_#{s.version}"}
   s.platform     = :ios
   s.requires_arc = true
   s.source_files = 'StreamingKit/StreamingKit/*.{h,m}'

--- a/StreamingKit/StreamingKit/STKAutoRecoveringHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKAutoRecoveringHTTPDataSource.m
@@ -372,7 +372,7 @@ static void PopulateOptionsWithDefault(STKAutoRecoveringHTTPDataSourceOptions* o
 -(void) dataSourceErrorOccured:(STKDataSource*)dataSource
 {
     const UInt32 httpStatusCode = self.innerDataSource.httpStatusCode;
-    const bool isRetryableStatus = httpStatusCode >= 200 && httpStatusCode < 300;
+    const bool isRetryableStatus = (httpStatusCode >= 200 && httpStatusCode < 300) || ![self hasGotNetworkConnection];
     
     NSLog(@"Error on source %@ with http status %@ – will %@.", dataSource, @(httpStatusCode), isRetryableStatus ? @"retry" : @"fail");
     

--- a/StreamingKit/StreamingKit/STKAutoRecoveringHTTPDataSource.m
+++ b/StreamingKit/StreamingKit/STKAutoRecoveringHTTPDataSource.m
@@ -46,6 +46,8 @@
 #define DEFAULT_WATCHDOG_PERIOD_SECONDS (8)
 #define DEFAULT_INACTIVE_PERIOD_BEFORE_RECONNECT_SECONDS (15)
 
+static const uint HTTP_RESPONSE_NOT_RECEIVED = 0;
+
 static uint64_t GetTickCount(void)
 {
     static mach_timebase_info_data_t sTimebaseInfo;
@@ -372,7 +374,7 @@ static void PopulateOptionsWithDefault(STKAutoRecoveringHTTPDataSourceOptions* o
 -(void) dataSourceErrorOccured:(STKDataSource*)dataSource
 {
     const UInt32 httpStatusCode = self.innerDataSource.httpStatusCode;
-    const bool isRetryableStatus = (httpStatusCode >= 200 && httpStatusCode < 300) || ![self hasGotNetworkConnection];
+    const bool isRetryableStatus = (httpStatusCode >= 200 && httpStatusCode < 300) || httpStatusCode == HTTP_RESPONSE_NOT_RECEIVED;
     
     NSLog(@"Error on source %@ with http status %@ – will %@.", dataSource, @(httpStatusCode), isRetryableStatus ? @"retry" : @"fail");
     


### PR DESCRIPTION
Allow to retry when there is no network connection.

The issue is caused when a stream opens the connection status code will be set to 0 as a default value. We should let a stream retrying until we receive an error code meaning there is an issue on the server side.

This change helps to retry in different scenarios:
- Initiating play without connection: As it starts with 0 status code it will immediately fail and not open to retry
- Seeking without connection: The connection will be reopened and reset to 0
- While playing network goes on/off constantly: The connection will be reopened and reset to 0
- When there is a network connection but due to high packet loss the connection status is still 0

| Before | After |
| ---------- | ---------- |
| <video src="https://user-images.githubusercontent.com/11375400/204816163-fe8f38a9-cccf-4be4-9f33-c88d764c2db8.MP4"> | <video src="https://user-images.githubusercontent.com/11375400/204816402-337f59fc-75e4-4efe-957e-223886a7a362.MP4"> |
| <video src="https://user-images.githubusercontent.com/11375400/204816198-c95042f1-4e21-47d7-9e09-5e14d4008663.MP4"> | <video src="https://user-images.githubusercontent.com/11375400/204816433-aa2a5ee3-5557-4745-b774-c98fc14c655c.MP4"> |
| <video src="https://user-images.githubusercontent.com/11375400/204816223-451bef6c-9c78-4cb2-ba7b-c4bb625a86bf.MP4"> | <video src="https://user-images.githubusercontent.com/11375400/204816449-7864b8f9-8d0f-48f7-9567-fb0e61495485.MP4"> |


